### PR TITLE
Link updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Hyku
-email: hybox-contact@googlegroups.com
+email: hyku-ideas@googlegroups.com
 description: > # this means to ignore newlines until "baseurl:"
   Digital Public Library of America, Stanford University, and DuraSpace,
   with funding from the Institute of Museum and Library Services,

--- a/_data/faqs.yaml
+++ b/_data/faqs.yaml
@@ -33,7 +33,7 @@
 - question: >-
     What descriptive metadata elements and standards does Hyku support?
   answer: >-
-    Hyku currently supports a basic metadata element set for a generic work, the same set of Dublin Core elements that ships with Hyrax. We are augmenting this set in two significant ways. First, we are ensuring that it is compatible with the <a href="http://dp.la/about/map/">DPLA Metadata Application Profile v4</a> so that works in Hyku can be readily published for harvesting by DPLA and its hubs without further mapping. Second, as we extend support for specific content types in Hyku, we will add specific elements relevant and appropriate to those content types. <br/><br>As for crosswalking your metadata (which might be in XML) into a format that Hyku will ultimately use (such as RDF), we're actively talking to interested institutions in the Samvera community on migration and mapping tools to support this work. Updates and announcements about this work will be posted here. In the meantime, we’d love to hear from you about your metadata questions. Please share your suggestions or questions about crosswalking/mapping strategies <a href="mailto :hybox-contact@googlegroups.com">by email</a>.
+    Hyku currently supports a basic metadata element set for a generic work, the same set of Dublin Core elements that ships with Hyrax. We are augmenting this set in two significant ways. First, we are ensuring that it is compatible with the <a href="http://dp.la/about/map/">DPLA Metadata Application Profile v4</a> so that works in Hyku can be readily published for harvesting by DPLA and its hubs without further mapping. Second, as we extend support for specific content types in Hyku, we will add specific elements relevant and appropriate to those content types. <br/><br>As for crosswalking your metadata (which might be in XML) into a format that Hyku will ultimately use (such as RDF), we're actively talking to interested institutions in the Samvera community on migration and mapping tools to support this work. Updates and announcements about this work will be posted here. In the meantime, we’d love to hear from you about your metadata questions. Please share your suggestions or questions about crosswalking/mapping strategies <a href="mailto :hyku-ideas@googlegroups.com">by email</a>.
 - question: >-
     How customizable and configurable is Hyku?
   answer: >-
@@ -63,14 +63,14 @@
   answer: >-
     Yes, Hyku allows uploaded content and descriptive metadata to be versioned. Each version persists in Fedora 4, and records who created the new version and when it was created. All versions are exposed to the depositor of the content and others who have been granted "edit" access. Only the most recent version is exposed to the public. (More robust version control tools may be implemented in a later development phase based on community requirements and priorities.)
 - question: >-
-    How can I stay informed of Hydra-in-a-Box project updates?
+    How can I stay informed of Hyku project updates?
   answer: >-
-    Join the <a href="https://groups.google.com/forum/#!forum/hybox-info">HyBox Info Mailing List</a> and follow <a href="https://twitter.com/HydraInABox">@HydraInABox</a> on Twitter for all the latest project news. General announcements and monthly updates are posted to the <a href="https://groups.google.com/forum/#!forum/samvera-community">Samvera Community List</a>; subscription to this group is open to all. Technical discussions occur as needed on the <a href="https://groups.google.com/forum/#!forum/samvera-tech">Samvera Tech List</a>; subscription to this group is also open to all. Increasingly technical discussions occur on the Samvera Slack team. All are welcome to join us on Slack, and it's easy to <a href="http://slack.samvera.org/">request an invitation</a>.
+    Join the <a href="https://groups.google.com/forum/#!forum/samvera-hyku">Hyku Mailing List</a> and follow <a href="https://twitter.com/HykuRepo">@HykuRepo</a> on Twitter for all the latest project news. General announcements and monthly updates are posted to the <a href="https://groups.google.com/forum/#!forum/samvera-community">Samvera Community List</a>; subscription to this group is open to all. Technical discussions occur as needed on the <a href="https://groups.google.com/forum/#!forum/samvera-tech">Samvera Tech List</a>; subscription to this group is also open to all. Increasingly technical discussions occur on the Samvera Slack team. All are welcome to join us on Slack, and it's easy to <a href="http://slack.samvera.org/">request an invitation</a>.
 - question: >-
-    How can I get involved in the Hydra-in-a-Box project?
+    How can I get involved in the Hyku project?
   answer: >-
-    Let’s talk! <a href="mailto:hybox-contact@googlegroups.com">Contact the Hydra-in-a-Box project team</a> and let us know where your interests lie.
+    Let’s talk! <a href="mailto:hyku-ideas@googlegroups.com">Contact the Hyku project team</a> and let us know where your interests lie.
 - question: >-
     I have an idea for a feature or functionality that Hyku should support. Do you want to hear it?
   answer: >-
-    Yes, we do! Please <a href="mailto:hybox-contact@googlegroups.com">send us an email</a>. If you have a GitHub account, feel free to submit your ideas directly in the <a href="https://github.com/samvera-labs/hyku/issues/new">Hyku repo</a>.
+    Yes, we do! Please <a href="mailto:hyku-ideas@googlegroups.com">send us an email</a>. If you have a GitHub account, feel free to submit your ideas directly in the <a href="https://github.com/samvera-labs/hyku/issues/new">Hyku repo</a>.

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,13 +8,13 @@
   url: faq.html
 
 - title: Wiki
-  url: https://wiki.duraspace.org/display/samvera/Hydra-in-a-Box
+  url: https://wiki.duraspace.org/display/hyku
   external: true
 
 - title: Mailing List
-  url: https://groups.google.com/group/hybox-info
+  url: https://groups.google.com/group/samvera-hyku
   external: true
 
 - title: Contact Us
-  url: mailto:hybox-contact@googlegroups.com
+  url: mailto:hyku-ideas@googlegroups.com
   external: true

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
             </div>
             <div class="6u">
                 <h2>Submit your ideas!</h2>
-                <p>We'd love to hear your ideas for features and functionality for Hyku. To submit your idea, please use <a href="http://bit.ly/hydrainabox-ideas">our form</a>, or visit <a href="https://github.com/samvera-labs/hybox-ideas">our project on GitHub</a>!</p>
+                <p>We'd love to hear your ideas for features and functionality for Hyku. To submit your idea, please use <a href="https://forms.gle/zACqsCxHT8HWoA5o6">our form</a>, or visit <a href="https://github.com/samvera/hyku">our project on GitHub</a>!</p>
                 <ul class="icons">
                     <li><a href="http://twitter.com/{{ site.twitter_username }}" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
                     <li><a href="https://github.com/{{ site.github_username }}" class="icon fa-github"><span class="label">GitHub</span></a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
             {% for navitem in site.data.navigation %}
             <li><a href="{% if navitem.external %}{% else %}{{ site.baseurl }}/{% endif %}{{ navitem.url }}">{{ navitem.title }}</a></li>
             {% endfor %}
-            <li><a href="http://bit.ly/hydrainabox-ideas" class="button special">Submit your ideas</a></li>
+            <li><a href="https://forms.gle/zACqsCxHT8HWoA5o6" class="button special">Submit your ideas</a></li>
         </ul>
     </nav>
 </header>

--- a/archive/blog.html
+++ b/archive/blog.html
@@ -40,7 +40,7 @@
 
         <!-- Header -->
 <header id="header" class="skel-layers-fixed">
-    <h1><a href="/" class="site-title" >Hydra-In-a-Box</a></h1>
+    <h1><a href="/archive/" class="site-title" >Hydra-In-a-Box</a></h1>
     <nav id="nav">
         <ul>
             <li><a href="/archive/">Home</a></li>

--- a/archive/faq.html
+++ b/archive/faq.html
@@ -40,7 +40,7 @@
 
         <!-- Header -->
 <header id="header" class="skel-layers-fixed">
-    <h1><a href="/" class="site-title" >Hydra-In-a-Box</a></h1>
+    <h1><a href="/archive/" class="site-title" >Hydra-In-a-Box</a></h1>
     <nav id="nav">
         <ul>
             <li><a href="/archive/">Home</a></li>


### PR DESCRIPTION
In Archive site, fixed links in header to stay in archive site instead of bouncing back to parent homepage.
In the Hyku parent site, updated contact, mailing list, wiki, and submit-ideas links in header/footer and on FAQ page to direct to Hyku resources instead of Hydra in a Box